### PR TITLE
解决向上移动最后一页时出现标题丢失的bug

### DIFF
--- a/js/vm.js
+++ b/js/vm.js
@@ -22,7 +22,7 @@ define(['data'], function (dataManager) {
     vm.currentSid = ko.computed(function () {
         var page = vm.currentPage();
         var pageList = vm.pageList();
-        return pageList[page].sid;
+        return pageList[page] ? pageList[page].sid : '';
     });
 
     // vm.currentLayout = ko.computed(function () {


### PR DESCRIPTION
具体原因应该是vm.js里currendSid监听了pageList,page.js里moveUpPage时会splice pageList，导致pageList的length会临时-1，而这时currentPage还是原length，所以会读出undefined
